### PR TITLE
Removed component-jquery as a dependency

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -17,7 +17,7 @@
 var ColorPicker = require('color-picker');
 
 var picker = new ColorPicker;
-picker.el.appendTo('body');
+picker.appendTo(document.body);
 picker.on('change', function(color){
   $('.rgb').text(color.toString()).css('background', color);
 });
@@ -50,6 +50,10 @@ picker.on('change', function(color){
 ### ColorPicker#color(str)
 
   Set the color value to `str`.
+
+### ColorPicker#appendTo(el)
+
+  Append color picker to given DOM element
 
 ## License
 

--- a/component.json
+++ b/component.json
@@ -9,9 +9,12 @@
     "ui"
   ],
   "dependencies": {
-    "component/jquery": "*",
     "component/autoscale-canvas": "*",
-    "component/emitter": "*"
+    "component/emitter": "*",
+    "component/query": "*",
+    "component/domify": "*",
+    "component/event": "*",
+    "anthonyshort/offset": "*"
   },
   "scripts": [
     "index.js",
@@ -20,5 +23,8 @@
   "styles": [
     "color-picker.css"
   ],
-  "license": "MIT"
+  "license": "MIT",
+  "development": {
+    "component/jquery": "*"
+  }
 }

--- a/index.js
+++ b/index.js
@@ -3,7 +3,10 @@
  * Module dependencies.
  */
 
-var o = require('jquery')
+var query = require('query')
+  , domify = require('domify')
+  , event = require('event')
+  , off = require('offset')
   , Emitter = require('emitter')
   , autoscale = require('autoscale-canvas');
 
@@ -34,7 +37,7 @@ function rgba(r,g,b,a) {
  */
 
 function localPos(e) {
-  var offset = o(e.target).offset();
+  var offset = off(e.target);
   return {
     x: e.pageX - offset.left,
     y: e.pageY - offset.top
@@ -53,9 +56,10 @@ function localPos(e) {
 
 function ColorPicker() {
   this._colorPos = {};
-  this.el = o(require('./template'));
-  this.main = this.el.find('.main').get(0);
-  this.spectrum = this.el.find('.spectrum').get(0);
+  this.el = domify(require('./template'));
+  // this.main = this.el.find('.main').get(0);
+  this.main = query('.main', this.el);
+  this.spectrum = query('.spectrum', this.el);
   this.hue(rgb(255, 0, 0));
   this.spectrumEvents();
   this.mainEvents();
@@ -120,7 +124,7 @@ ColorPicker.prototype.height = function(n){
 
 ColorPicker.prototype.spectrumEvents = function(){
   var self = this
-    , canvas = o(this.spectrum)
+    , canvas = this.spectrum
     , down;
 
   function update(e) {
@@ -132,17 +136,17 @@ ColorPicker.prototype.spectrumEvents = function(){
     self.render();
   }
 
-  canvas.mousedown(function(e){
+  event.bind(canvas, 'mousedown', function(e) {
     e.preventDefault();
     down = true;
     update(e);
   });
 
-  canvas.mousemove(function(e){
+  event.bind(canvas, 'mousemove', function(e){
     if (down) update(e);
   });
 
-  canvas.mouseup(function(){
+  event.bind(canvas, 'mouseup', function() {
     down = false;
   });
 };
@@ -155,7 +159,7 @@ ColorPicker.prototype.spectrumEvents = function(){
 
 ColorPicker.prototype.mainEvents = function(){
   var self = this
-    , canvas = o(this.main)
+    , canvas = this.main
     , down;
 
   function update(e) {
@@ -168,17 +172,17 @@ ColorPicker.prototype.mainEvents = function(){
     self.render();
   }
 
-  canvas.mousedown(function(e){
+  event.bind(canvas, 'mousedown', function(e) {
     e.preventDefault();
     down = true;
     update(e);
   });
 
-  canvas.mousemove(function(e){
+  event.bind(canvas, 'mousemove', function(e){
     if (down) update(e);
   });
 
-  canvas.mouseup(function(){
+  event.bind(canvas, 'mouseup', function() {
     down = false;
   });
 };
@@ -357,4 +361,16 @@ ColorPicker.prototype.renderMain = function(options){
 
   ctx.beginPath();
   ctx.restore();
+};
+
+/**
+ * Append color picker to element
+ *
+ * @param {DomElement} el
+ * @returns {ColorPicker} this
+ * @api public
+ */
+ColorPicker.prototype.appendTo = function(el) {
+  el.appendChild(this.el);
+  return this;
 };

--- a/test/index.html
+++ b/test/index.html
@@ -29,23 +29,23 @@
       }
 
       var picker = new ColorPicker;
-      picker.el.appendTo('body');
+      picker.appendTo(document.body);
       picker.on('change', update);
 
       var picker = new ColorPicker;
       picker.size(100);
-      picker.el.appendTo('body');
+      picker.appendTo(document.body);
       picker.on('change', update);
 
       var picker = new ColorPicker;
       picker.width(50);
       picker.height(100);
-      picker.el.appendTo('body');
+      picker.appendTo(document.body);
       picker.on('change', update);
 
       var picker = new ColorPicker;
       picker.size(50);
-      picker.el.appendTo('body');
+      picker.appendTo(document.body);
       picker.on('change', update);
     </script>
   </body>


### PR DESCRIPTION
In the theme of small dependencies, I rewrote the bits that used jquery and replaced them with some suitable components.
Added `ColorPicker#appendTo(el)` for convenience as `this.el` is no longer wrapped in `$(this.el)`
Updated Readme and test.html to reflect changes.
